### PR TITLE
simplified way of declaring error_code enum

### DIFF
--- a/docs/generic_error_category.md
+++ b/docs/generic_error_category.md
@@ -15,16 +15,32 @@ The first step involves including the necessary headers from the `simple_enum` l
 
 ## Declaring Custom Error Enum
 
+
 Define a custom error enumeration within your namespace for use by functions. This example uses `function_error` as the custom enumeration:
 
 ```cpp
 namespace custom_error_example 
   {
-enum class function_error {
+enum class function_error 
+  {
   failed_other_reason,
   unhandled_exaption
   };
 ```
+
+## Simplified modern adl way using only adl_enum_bounds
+
+Following the declaration, define the bounds for your custom enum using the `adl_enum_bounds` function, ensuring the enum is compatible with the `simple_enum` library's functionalities and pass last argument as true declaring it as error enum:
+
+```cpp
+consteval auto adl_enum_bounds(function_error) 
+  {
+  using enum function_error;
+  return simple_enum::adl_info{failed_other_reason, unhandled_exaption, true };
+  }
+}  // namespace custom_error_example
+```
+## Alternative old way with separate adl_decl_error_code or by specializing std::is_error_code_enum
 
 Following the declaration, define the bounds for your custom enum using the `adl_enum_bounds` function, ensuring the enum is compatible with the `simple_enum` library's functionalities:
 
@@ -32,12 +48,12 @@ Following the declaration, define the bounds for your custom enum using the `adl
 consteval auto adl_enum_bounds(function_error) 
   {
   using enum function_error;
-  return simple_enum::adl_info{failed_other_reason, unhandled_exaption};
+  return simple_enum::adl_info{failed_other_reason, unhandled_exaption };
   }
 }  // namespace custom_error_example
 ```
 
-## Making the Enum Compatible with `std::is_error_code_enum`
+### Making the Enum Compatible with `std::is_error_code_enum`
 
 To integrate seamlessly with the C++ error handling mechanisms You have to either declare adl function
 ```cpp

--- a/examples/generic_error_category.cc
+++ b/examples/generic_error_category.cc
@@ -20,16 +20,25 @@ enum class function_error
   unhandled_exaption
   };
 
+// There are 3 ways to declare enum as error_code
+#define USE_ADL_WAY_TO_DECL_ERROR_CODE 1
+
+#if USE_ADL_WAY_TO_DECL_ERROR_CODE == 1
+// as part of adl_enum_bounds passing true as last constructor argument
+consteval auto adl_enum_bounds(function_error)
+  {
+  using enum function_error;
+  return simple_enum::adl_info{failed_other_reason, unhandled_exaption, true};
+  }
+
+#elif USE_ADL_WAY_TO_DECL_ERROR_CODE == 2
+// old way of adl_decl_error_code separated from adl_enum_bounds
 consteval auto adl_enum_bounds(function_error)
   {
   using enum function_error;
   return simple_enum::adl_info{failed_other_reason, unhandled_exaption};
   }
 
-// There are 2 ways to declare enum as error_code
-#define USE_ADL_WAY_TO_DECL_ERROR_CODE 1
-
-#if USE_ADL_WAY_TO_DECL_ERROR_CODE
 // using provided by simple_enum partial specialization of std::is_error_code_enum
 consteval auto adl_decl_error_code(function_error) -> bool { return true; }
 #endif

--- a/include/simple_enum/core.hpp
+++ b/include/simple_enum/core.hpp
@@ -58,6 +58,18 @@ struct adl_info
   {
   enumeration first;
   enumeration last;
+  bool error_code_enum = false;
+
+  constexpr adl_info() noexcept = default;
+
+  constexpr adl_info(enumeration f, enumeration l) noexcept : first{f}, last{l}, error_code_enum{false} {}
+
+  constexpr adl_info(enumeration f, enumeration l, bool is_error_code_enum) noexcept :
+      first{f},
+      last{l},
+      error_code_enum{is_error_code_enum}
+    {
+    }
   };
 
 template<enum_concept enumeration>

--- a/include/simple_enum/generic_error_category.hpp
+++ b/include/simple_enum/generic_error_category.hpp
@@ -10,13 +10,34 @@
 
 namespace simple_enum::inline v0_7
   {
+namespace detail
+  {
+  // clang-format off
+  // adl error code enum may be now declared directly inside adl_enum_bounds
+  template<typename T>
+  concept adl_info_error_declared_enum =
+    detail::has_valid_adl_enum_bounds<T> &&
+    requires { requires adl_enum_bounds(T{}).error_code_enum == true; };
+    
+  template<typename T>
+  concept adl_decl_error_code_declared_enum =
+    requires(T enum_value) 
+      {
+      { adl_decl_error_code(enum_value) } -> std::same_as<bool>;
+      adl_decl_error_code(enum_value) == true;
+      };
+  // clang-format on
+  }  // namespace detail
+
 namespace concepts
   {
+  // clang-format off
+
+      
   template<typename T>
-  concept declared_error_code = bounded_enum<T> && requires(T enum_value) {
-    { adl_decl_error_code(enum_value) } -> std::same_as<bool>;
-    adl_decl_error_code(enum_value) == true;
-  };
+  concept declared_error_code = bounded_enum<T> 
+    and ( detail::adl_decl_error_code_declared_enum<T> or detail::adl_info_error_declared_enum<T> );
+  // clang-format on
   /**
    * @concept error_enum
    * @brief Checks if a type is an enum and specialized for std::is_error_code_enum.

--- a/tests/glaze_enum_name_ut.cc
+++ b/tests/glaze_enum_name_ut.cc
@@ -69,8 +69,20 @@ struct complex_response_t
   std::string name;
   };
 
+struct string_view_test
+  {
+  std::string_view value;
+  Color color;
+  };
+
 int main()
   {
+  "write_file_json test"_test = []
+  {
+    string_view_test data{""};
+    auto reserr{glz::write_file_json<pretty>(data, std::string{"string_view_test"}, std::string{})};
+    expect(reserr.ec == glz::error_code::none);
+  };
   "write_file_json test"_test = []
   {
     constexpr test_data_t data{.enum_field = test_enum_e::baz};


### PR DESCRIPTION
adds a simplified way of declaring error enumeration by declaring only adl_enum_bounds