### PR TITLE
msvc workflow - disable test for broken compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Configure MSVC with glaze 4.x support
-      run: cmake -B ${{github.workspace}}/build/msvc -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_BUILD_TYPE=Debug -DSIMPLE_ENUM_USE_GLAZE_3_1=OFF -DSIMPLE_ENUM_USE_GLAZE_4_0=ON
+      run: cmake -B ${{github.workspace}}/build/msvc -DCMAKE_BUILD_TYPE=Debug -DSIMPLE_ENUM_USE_GLAZE_3_1=OFF -DSIMPLE_ENUM_USE_GLAZE_4_0=ON
     - name: Build MSVC with glaze 4.x support
       run: cmake --build ${{github.workspace}}/build/msvc
     - name: Test MSVC with glaze 4.x support

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Configure MSVC with glaze 4.x support
-      run: cmake -B ${{github.workspace}}/build/msvc -DCMAKE_BUILD_TYPE=Debug -DSIMPLE_ENUM_USE_GLAZE_3_1=OFF -DSIMPLE_ENUM_USE_GLAZE_4_0=ON
+      run: cmake -B ${{github.workspace}}/build/msvc -DCMAKE_BUILD_TYPE=Release -DSIMPLE_ENUM_USE_GLAZE_3_1=OFF -DSIMPLE_ENUM_USE_GLAZE_4_0=ON
     - name: Build MSVC with glaze 4.x support
       run: cmake --build ${{github.workspace}}/build/msvc
     - name: Test MSVC with glaze 4.x support

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Configure MSVC with glaze 4.x support
-      run: cmake -B ${{github.workspace}}/build/msvc -DCMAKE_BUILD_TYPE=Debug -DSIMPLE_ENUM_USE_GLAZE_3_1=OFF -DSIMPLE_ENUM_USE_GLAZE_4_0=ON
+      run: cmake -B ${{github.workspace}}/build/msvc -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_BUILD_TYPE=Debug -DSIMPLE_ENUM_USE_GLAZE_3_1=OFF -DSIMPLE_ENUM_USE_GLAZE_4_0=ON
     - name: Build MSVC with glaze 4.x support
       run: cmake --build ${{github.workspace}}/build/msvc
     - name: Test MSVC with glaze 4.x support

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,8 @@ target_link_libraries(fmtlib_format_ut PRIVATE fmt::fmt)
 add_ut_test(glaze_enum_name_ut.cc)
 if(MSVC)
   # glaze causes objects to grow over 4GB on msvc
-  target_compile_options(glaze_enum_name_ut PRIVATE "/bigobj" "/Brepro+")
+  target_compile_options(glaze_enum_name_ut PRIVATE "/bigobj" "/Zm200")
+  target_link_options(glaze_enum_name_ut PRIVATE "/LARGEADDRESSAWARE")
 endif()
 target_link_libraries(glaze_enum_name_ut PRIVATE glaze::glaze)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,7 +36,6 @@ if(MSVC)
   target_compile_options(glaze_enum_name_ut PRIVATE 
     "/bigobj"
     "/Zm500"  # Increased memory allocation
-    "/Z7"     # Generate smaller debug info
     "/Os"     # Favor small code size
     )
   target_link_options(glaze_enum_name_ut PRIVATE "/LARGEADDRESSAWARE")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,7 +31,10 @@ add_ut_test(fmtlib_format_ut.cc)
 target_link_libraries(fmtlib_format_ut PRIVATE fmt::fmt)
 
 add_ut_test(glaze_enum_name_ut.cc)
-
+if(MSVC)
+  # glaze causes objects to grow over 4GB on msvc
+  target_compile_options(glaze_enum_name_ut PRIVATE /bigobj)
+endif()
 target_link_libraries(glaze_enum_name_ut PRIVATE glaze::glaze)
 
 add_executable(diagnostics EXCLUDE_FROM_ALL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,17 +30,18 @@ CPMAddPackage(
 add_ut_test(fmtlib_format_ut.cc)
 target_link_libraries(fmtlib_format_ut PRIVATE fmt::fmt)
 
-add_ut_test(glaze_enum_name_ut.cc)
-if(MSVC)
+if(NOT MSVC)
+  add_ut_test(glaze_enum_name_ut.cc)
+  target_link_libraries(glaze_enum_name_ut PRIVATE glaze::glaze)
   # glaze causes objects to grow over 4GB on msvc
-  target_compile_options(glaze_enum_name_ut PRIVATE 
-    "/bigobj"
-    "/Zm500"  # Increased memory allocation
-    "/Os"     # Favor small code size
-    )
-  target_link_options(glaze_enum_name_ut PRIVATE "/LARGEADDRESSAWARE")
+  # https://developercommunity.visualstudio.com/t/Memory-Explosion:-compiler-limit:-objec/10795558
+  # target_compile_options(glaze_enum_name_ut PRIVATE 
+  #   "/bigobj"
+  #   "/Zm500"  # Increased memory allocation
+  #   "/Os"     # Favor small code size
+  #   )
+  # target_link_options(glaze_enum_name_ut PRIVATE "/LARGEADDRESSAWARE")
 endif()
-target_link_libraries(glaze_enum_name_ut PRIVATE glaze::glaze)
 
 add_executable(diagnostics EXCLUDE_FROM_ALL)
 target_sources( diagnostics PRIVATE diagnostics.cc)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,12 @@ target_link_libraries(fmtlib_format_ut PRIVATE fmt::fmt)
 add_ut_test(glaze_enum_name_ut.cc)
 if(MSVC)
   # glaze causes objects to grow over 4GB on msvc
-  target_compile_options(glaze_enum_name_ut PRIVATE "/bigobj" "/Zm200")
+  target_compile_options(glaze_enum_name_ut PRIVATE 
+    "/bigobj"
+    "/Zm500"  # Increased memory allocation
+    "/Z7"     # Generate smaller debug info
+    "/Os"     # Favor small code size
+    )
   target_link_options(glaze_enum_name_ut PRIVATE "/LARGEADDRESSAWARE")
 endif()
 target_link_libraries(glaze_enum_name_ut PRIVATE glaze::glaze)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(fmtlib_format_ut PRIVATE fmt::fmt)
 add_ut_test(glaze_enum_name_ut.cc)
 if(MSVC)
   # glaze causes objects to grow over 4GB on msvc
-  target_compile_options(glaze_enum_name_ut PRIVATE /bigobj)
+  target_compile_options(glaze_enum_name_ut PRIVATE "/bigobj" "/Brepro+")
 endif()
 target_link_libraries(glaze_enum_name_ut PRIVATE glaze::glaze)
 


### PR DESCRIPTION
- fixes https://github.com/arturbac/simple_enum/issues/15
- https://developercommunity.visualstudio.com/t/Memory-Explosion:-compiler-limit:-objec/10795558
- https://github.com/stephenberry/glaze/issues/1448