### PR TITLE
clang - mark unsafe memory usage

### DIFF
--- a/cmake/default_clang_warnings.cmake
+++ b/cmake/default_clang_warnings.cmake
@@ -1,8 +1,9 @@
 set( clang_default_warnings
-  -Weverything -Wno-unsafe-buffer-usage -Wno-pre-c++17-compat
+  -Weverything -Wunsafe-buffer-usage -Wno-pre-c++17-compat
   -Wno-c++98-compat -Wno-pre-c++14-compat -Wno-pre-c++17-compat -Wno-c++98-compat-pedantic
   -Wno-pre-c++20-compat-pedantic -Wno-padded -Wno-exit-time-destructors -Wno-global-constructors
   -Wno-c++20-compat # 'consteval' specifier is incompatible with C++ standards before C++20
   -Wno-undefined-func-template
   -Wno-ctad-maybe-unsupported
+  -fsafe-buffer-usage-suggestions
   )

--- a/include/simple_enum/basic_fixed_string.hpp
+++ b/include/simple_enum/basic_fixed_string.hpp
@@ -35,7 +35,10 @@ struct basic_fixed_string
 
   static constexpr std::size_t size() noexcept { return N; }
 
-  constexpr auto operator==(basic_fixed_string const & rh) const noexcept -> bool = default;
+  constexpr auto operator==(basic_fixed_string const & rh) const noexcept -> bool
+    {
+    return std::equal(data(), std::next(data(), N), rh.data());
+    }
   };
 
 template<typename T, std::size_t N>
@@ -82,7 +85,13 @@ consteval auto as_basic_fixed_string(char const * input) -> basic_fixed_string<C
   {
   basic_fixed_string<CharT, N> result{};
   for(std::size_t i = 0; i < N; ++i)
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     result.str[i] = input[i];
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
   return result;
   }
 
@@ -93,7 +102,13 @@ consteval auto to_camel_case(basic_fixed_string<CharT, N> const & input) -> basi
 
   detail::camel_case_character_t camel_case_character;
   for(std::size_t i = 0; i < N; ++i)
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     result.str[i] = camel_case_character(input.str[i]);
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
 
   return result;
   }

--- a/include/simple_enum/enum_cast.hpp
+++ b/include/simple_enum/enum_cast.hpp
@@ -60,6 +60,9 @@ namespace detail
       return last;
 
     auto size = last - first;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     auto middle = first + size / 2;
 
     if(less(*middle, v))
@@ -79,6 +82,9 @@ namespace detail
     for(; first < last; ++first)
       if(!less(*first, v))
         break;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     return first;
     }
 
@@ -121,8 +127,8 @@ template<enum_concept enum_type>
 struct enum_cast_t
   {
   [[nodiscard]]
-  static_call_operator constexpr auto operator()(std::string_view value
-  ) static_call_operator_const noexcept -> cxx23::expected<enum_type, enum_cast_error>
+  static_call_operator constexpr auto operator()(std::string_view value) static_call_operator_const noexcept
+    -> cxx23::expected<enum_type, enum_cast_error>
     {
     using enum_meta_info = detail::enum_meta_info_t<enum_type>;
     using underlying_type = std::underlying_type_t<enum_type>;

--- a/include/simple_enum/fmtlib_format.hpp
+++ b/include/simple_enum/fmtlib_format.hpp
@@ -6,7 +6,7 @@
 #include <simple_enum/simple_enum.hpp>
 #ifdef __clang__
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Weverything"
 #endif
 #include <fmt/format.h>
 #ifdef __clang__

--- a/include/simple_enum/simple_enum.hpp
+++ b/include/simple_enum/simple_enum.hpp
@@ -173,14 +173,23 @@ namespace detail
 
   constexpr char const * find_sentinel(char const * str)
     {
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     while(*str != ':' && *str != ')')
       ++str;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     return str;
     }
 
   template<char end_of_enum = ']'>
   constexpr void parse_enumeration_name(char const * str, meta_name & result) noexcept
     {
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     if(*str == '(')
       ++str;
     char const * prev_colon = str;
@@ -236,6 +245,9 @@ namespace detail
 #endif
     else if(prev_colon[0] == ')' && prev_colon[1] == ':')
       prev_colon += 3;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     // Calculate the size and set the result
     result.data = prev_colon;
     result.size = size_t(current_colon - prev_colon);
@@ -246,13 +258,22 @@ namespace detail
     {
     char const * const func{se::f<enumeration{}>()};
     meta_name result;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     parse_enumeration_name<se::end_of_enumeration_name>(func + se::initial_offset + 1, result);
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     return result;
     }
 
   template<auto enumeration>
   constexpr auto first_pass(meta_name & res) noexcept
     {
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     char const * const func{se::f<enumeration>()};
     char const * end_of_name{func + se::initial_offset};
     char const * last_colon{end_of_name};
@@ -275,6 +296,9 @@ namespace detail
 
     res.data = last_colon + 1;
     res.size = size_t(end_of_name - res.data);
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
 #ifdef _MSC_VER
     return size_t(last_colon - func) + 1 - was_undefined;
 #else
@@ -285,12 +309,17 @@ namespace detail
   template<auto enumeration>
   constexpr void cont_pass(meta_name & res, std::size_t enum_beg) noexcept
     {
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     char const * const func{se::f<enumeration>()};
     char const * end_of_name{func + enum_beg};
     char const * enumeration_name{end_of_name};
     while(*end_of_name != se::end_of_enumeration_name)
       ++end_of_name;  // for other enumerations we only need to find end of string
-
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     res.data = enumeration_name;
     res.size = size_t(end_of_name - res.data);
     }
@@ -344,8 +373,8 @@ namespace detail
 struct enum_name_t
   {
   template<enum_concept enum_type>
-  static_call_operator constexpr auto operator()(enum_type value
-  ) static_call_operator_const noexcept -> std::string_view
+  static_call_operator constexpr auto operator()(enum_type value) static_call_operator_const noexcept
+    -> std::string_view
     {
     using enum_meta_info = detail::enum_meta_info_t<enum_type>;
     auto const requested_index{simple_enum::detail::to_underlying(value)};

--- a/include/simple_enum/std_format.hpp
+++ b/include/simple_enum/std_format.hpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 #if (defined(__cpp_lib_format) && !(defined(__clang__) && defined(__GLIBCXX__) && __GLIBCXX__ < 202103L)) \
-  || ((_LIBCPP_VERSION >= 1800 || __GLIBCXX__ >= 202103L) && __cplusplus >= 202002L)
+  || ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 1800 || __GLIBCXX__ >= 202103L) && __cplusplus >= 202002L)
 #include <format>
 #define SIMPLE_ENUM_STD_FORMAT_ENABLED
 

--- a/include/simple_enum/std_format.hpp
+++ b/include/simple_enum/std_format.hpp
@@ -6,7 +6,7 @@
 #include <simple_enum/simple_enum.hpp>
 #include <type_traits>
 
-#if(defined(__cpp_lib_format) && !(defined(__clang__) && __GLIBCXX__ < 202103L)) \
+#if (defined(__cpp_lib_format) && !(defined(__clang__) && defined(__GLIBCXX__) && __GLIBCXX__ < 202103L)) \
   || ((_LIBCPP_VERSION >= 1800 || __GLIBCXX__ >= 202103L) && __cplusplus >= 202002L)
 #include <format>
 #define SIMPLE_ENUM_STD_FORMAT_ENABLED

--- a/tests/generic_error_category_ut.cc
+++ b/tests/generic_error_category_ut.cc
@@ -24,6 +24,18 @@ suite basic_fixed_string_tests = []
     constexpr basic_fixed_string my_string{"Test"};
     expect(4_u == my_string.size()) << "String size is incorrect";
   };
+
+  "basic_fixed_string operator == test"_test = []
+  {
+    constexpr basic_fixed_string my_string{"Test"};
+    constexpr basic_fixed_string my_string2{"Test"};
+    constexpr basic_fixed_string my_string3{"Tes3"};
+    expect(my_string == my_string2);
+    expect(my_string2 == my_string2);
+    expect(my_string2 == my_string);
+    expect(my_string2 != my_string3);
+    expect(my_string != my_string3);
+  };
 };
 
 static constexpr basic_fixed_string my_error_str{"ErrorCategoryName"};

--- a/tests/simple_enum_tests.hpp
+++ b/tests/simple_enum_tests.hpp
@@ -7,6 +7,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wctad-maybe-unsupported"
 #pragma clang diagnostic ignored "-Wreserved-identifier"
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #pragma clang diagnostic ignored "-Wundef"
 #endif
 

--- a/tests/test_simple_enum.cc
+++ b/tests/test_simple_enum.cc
@@ -442,22 +442,28 @@ enum class ScopedEnum
   };
 // Testing an enumeration with no values as a corner case
 enum struct EmptyEnum
-{
-};
+  {
+  };
 // anonymous namespace
 enum class MultiValuedEnum
-{
+  {
   Value1,
   Value2,
   Value3
-};
+  };
 static ut::suite<"enumeration_name_tests"> enumeration_name_tests = []
 {
   "ScopedEnum_name"_test = []
   {
     char const * const func{se::f<ScopedEnum{}>()};
     meta_name result;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     parse_enumeration_name<se::end_of_enumeration_name>(func + se::initial_offset + 1, result);
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     expect(eq(result.as_view(), "ScopedEnum"sv));
     expect(eq(enumeration_name_v<ScopedEnum>, "ScopedEnum"sv));
   };
@@ -466,7 +472,13 @@ static ut::suite<"enumeration_name_tests"> enumeration_name_tests = []
   {
     char const * const func{se::f<EmptyEnum{}>()};
     meta_name result;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     parse_enumeration_name<se::end_of_enumeration_name>(func + se::initial_offset + 1, result);
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     expect(eq(result.as_view(), "EmptyEnum"sv)) << func;
     expect(eq(enumeration_name_v<EmptyEnum>, "EmptyEnum"sv));
   };
@@ -475,7 +487,13 @@ static ut::suite<"enumeration_name_tests"> enumeration_name_tests = []
   {
     char const * const func{se::f<MultiValuedEnum{}>()};
     meta_name result;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     parse_enumeration_name<se::end_of_enumeration_name>(func + se::initial_offset + 1, result);
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     expect(eq(result.as_view(), "MultiValuedEnum"sv)) << func;
     expect(eq(enumeration_name_v<MultiValuedEnum>, "MultiValuedEnum"sv));
   };


### PR DESCRIPTION
- mark unsafe memory usage for not polluting user code with warnings by including simple_enum