### PR TITLE
initial c++ module support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,58 @@ jobs:
       
     - name: ci-gcc-c++26
       run: cmake --workflow --preset="ci-gcc-c++26"
-
-  build-and-test-clang:
+      
+  build-and-test-clang-20:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Add LLVM Repository
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 20
+        
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake g++-14 ninja-build clang-20 libfmt-dev libc++-20-dev libc++abi-20-dev clang-tools-20
+        
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 200
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 200
+        sudo update-alternatives --install /usr/bin/clang-scan-deps clang-scan-deps /usr/bin/clang-scan-deps-20 200
+         
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 140
+         
+        sudo update-alternatives --set clang /usr/bin/clang-20
+        sudo update-alternatives --set clang++ /usr/bin/clang++-20
+        sudo update-alternatives --set clang-scan-deps /usr/bin/clang-scan-deps-20
+         
+        sudo update-alternatives --set gcc /usr/bin/gcc-14
+        sudo update-alternatives --set g++ /usr/bin/g++-14
+        
+        clang++ --version
+        g++ --version
+        
+    - name: ci-clang-libstdc++
+      run: cmake --workflow --preset="ci-clang-libstdc++"
+      
+    - name: ci-module-clang-libstdc++
+      run: cmake --workflow --preset="ci-module-clang-libstdc++"
+      
+    - name: ci-clang-libc++
+      run: cmake --workflow --preset="ci-clang-libc++"
+      
+    - name: ci-module-clang-libc++
+      run: cmake --workflow --preset="ci-module-clang-libc++"
+      
+    - name: ci-clang-libstdc++-c++26
+      run: cmake --workflow --preset="ci-clang-libstdc++-c++26"
+      
+    - name: ci-clang-libc++-c++26
+      run: cmake --workflow --preset="ci-clang-libc++-c++26"
+      
+  build-and-test-clang-19:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
@@ -66,21 +116,12 @@ jobs:
         
     - name: ci-clang-libstdc++
       run: cmake --workflow --preset="ci-clang-libstdc++"
-      
-    - name: ci-module-clang-libstdc++
-      run: cmake --workflow --preset="ci-module-clang-libstdc++"
-      
+
     - name: ci-clang-libc++
       run: cmake --workflow --preset="ci-clang-libc++"
       
     - name: ci-module-clang-libc++
       run: cmake --workflow --preset="ci-module-clang-libc++"
-      
-    - name: ci-clang-libstdc++-c++26
-      run: cmake --workflow --preset="ci-clang-libstdc++-c++26"
-      
-    - name: ci-clang-libc++-c++26
-      run: cmake --workflow --preset="ci-clang-libc++-c++26"
 
   build-and-test-msvc:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,15 +45,18 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake g++-14 ninja-build clang-19 libfmt-dev libc++-19-dev libc++abi-19-dev
+        sudo apt-get install -y cmake g++-14 ninja-build clang-19 libfmt-dev libc++-19-dev libc++abi-19-dev clang-tools-extra
+        
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 190
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 190
+        sudo update-alternatives --install /usr/bin/clang-scan-deps clang-scan-deps /usr/bin/clang-scan-deps-19 190
          
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 140
          
         sudo update-alternatives --set clang /usr/bin/clang-19
         sudo update-alternatives --set clang++ /usr/bin/clang++-19
+        sudo update-alternatives --set clang-scan-deps /usr/bin/clang-scan-deps-19
          
         sudo update-alternatives --set gcc /usr/bin/gcc-14
         sudo update-alternatives --set g++ /usr/bin/g++-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake g++-14 ninja-build clang-19 libfmt-dev libc++-19-dev libc++abi-19-dev clang-tools-extra
+        sudo apt-get install -y cmake g++-14 ninja-build clang-19 libfmt-dev libc++-19-dev libc++abi-19-dev clang-tools-19
         
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 190
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 190

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,22 @@ jobs:
         
         clang++ --version
         g++ --version
+        
     - name: ci-clang-libstdc++
       run: cmake --workflow --preset="ci-clang-libstdc++"
+      
+    - name: ci-module-clang-libstdc++
+      run: cmake --workflow --preset="ci-module-clang-libstdc++"
+      
     - name: ci-clang-libc++
       run: cmake --workflow --preset="ci-clang-libc++"
       
+    - name: ci-module-clang-libc++
+      run: cmake --workflow --preset="ci-module-clang-libc++"
+      
     - name: ci-clang-libstdc++-c++26
       run: cmake --workflow --preset="ci-clang-libstdc++-c++26"
+      
     - name: ci-clang-libc++-c++26
       run: cmake --workflow --preset="ci-clang-libc++-c++26"
 
@@ -74,11 +83,11 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Configure MSVC with glaze 4.x support
-      run: cmake -B ${{github.workspace}}/build/msvc -DCMAKE_BUILD_TYPE=Release -DSIMPLE_ENUM_USE_GLAZE_3_1=OFF -DSIMPLE_ENUM_USE_GLAZE_4_0=ON
-    - name: Build MSVC with glaze 4.x support
+    - name: Configure MSVC
+      run: cmake -B ${{github.workspace}}/build/msvc -DCMAKE_BUILD_TYPE=Release
+    - name: Build MSVC
       run: cmake --build ${{github.workspace}}/build/msvc
-    - name: Test MSVC with glaze 4.x support
+    - name: Test MSVC
       working-directory: ${{github.workspace}}/build/msvc
       run: ctest -C Debug
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
-cmake_policy(
-  SET
-  CMP0167
-  NEW)
-cmake_policy(
-  SET
-  CMP0175
-  NEW)
+cmake_minimum_required(VERSION 3.28..3.31)
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/extract_version.cmake)
 
@@ -51,30 +43,80 @@ option(
   "Enable cmake targets"
   ON)
 
-add_library(simple_enum INTERFACE)
+option(
+  SIMPLE_ENUM_ENABLE_MODULE
+  "Build C++23 module instead of INTERFACE library"
+  OFF)
 
-target_compile_features(simple_enum INTERFACE cxx_std_23)
+if(SIMPLE_ENUM_ENABLE_MODULE)
+  set(CMAKE_CXX_SCAN_FOR_MODULES ON)
+
+  add_library(simple_enum STATIC)
+  target_compile_definitions(simple_enum PUBLIC SIMPLE_ENUM_CXX_MODULE)
+  target_sources(
+    simple_enum
+    PRIVATE FILE_SET
+            HEADERS
+            BASE_DIRS
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    PUBLIC FILE_SET
+           ext_support
+           TYPE
+           HEADERS
+           BASE_DIRS
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ext_support>
+           $<INSTALL_INTERFACE:include>
+    PUBLIC FILE_SET
+           CXX_MODULES
+           FILES
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/module/simple_enum.cxx>
+           $<INSTALL_INTERFACE:include>)
+
+else()
+  set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+  add_library(simple_enum INTERFACE)
+  target_sources(
+    simple_enum
+    INTERFACE FILE_SET
+              HEADERS
+              BASE_DIRS
+              $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+              $<INSTALL_INTERFACE:include>
+    INTERFACE FILE_SET
+              ext_support
+              TYPE
+              HEADERS
+              BASE_DIRS
+              $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ext_support>
+              $<INSTALL_INTERFACE:include>)
+endif()
+
+set_target_properties(
+  simple_enum
+  PROPERTIES CXX_STANDARD 23
+             CXX_STANDARD_REQUIRED YES
+             CXX_EXTENSIONS OFF
+             CXX_SCAN_FOR_MODULES ${SIMPLE_ENUM_ENABLE_MODULE})
 
 if(SIMPLE_ENUM_OPT_IN_STATIC_ASSERTS)
   target_compile_definitions(simple_enum INTERFACE SIMPLE_ENUM_OPT_IN_STATIC_ASSERTS=1)
 endif()
-
-target_sources(
-  simple_enum
-  INTERFACE FILE_SET
-            HEADERS
-            BASE_DIRS
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-            $<INSTALL_INTERFACE:include>)
 
 install(
   TARGETS simple_enum
   EXPORT simple_enum_targets
   INCLUDES
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  FILE_SET HEADERS)
+  FILE_SET
+  HEADERS
+  FILE_SET
+  ext_support
+  FILE_SET
+  CXX_MODULES
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/modules)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ext_support/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 configure_package_config_file(cmake/simple_enumConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/simple_enumConfig.cmake
                               INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simple_enum)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # simple_enum
 
 ## Features
-
+- **Initial c++ module support** build mode, tested with clang 19 and 20
 - **Bounded Enum Views**: Provides `enum_view` for iterating over bounded enumerations, leveraging `std::ranges::views`.
 - **Enum to String and Back**: Supports conversion from enum to `std::string_view` and vice versa with minimal compile-time overhead.
 - **Enumeration Indexing**: Offers `enum_index`, allowing for index retrieval of enum values based on compile-time metadata.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # simple_enum
 
 ## Features
-- **Initial c++ module support** build mode, tested with clang 19 and 20
+- **Initial c++ module support** build mode, tested with clang 19 libc++ and clang 20 libc++,libstdc++
 - **Bounded Enum Views**: Provides `enum_view` for iterating over bounded enumerations, leveraging `std::ranges::views`.
 - **Enum to String and Back**: Supports conversion from enum to `std::string_view` and vice versa with minimal compile-time overhead.
 - **Enumeration Indexing**: Offers `enum_index`, allowing for index retrieval of enum values based on compile-time metadata.

--- a/cmake/preset-build.json
+++ b/cmake/preset-build.json
@@ -32,6 +32,19 @@
     {
       "name": "ci-gcc",
       "configurePreset": "ci-gcc"
+    },
+    
+    {
+      "name": "ci-module-clang-libstdc++",
+      "configurePreset": "ci-module-clang-libstdc++"
+    },
+    {
+      "name": "ci-module-clang-libc++",
+      "configurePreset": "ci-module-clang-libc++"
+    },
+    {
+      "name": "ci-module-gcc",
+      "configurePreset": "ci-module-gcc"
     }
   ]
 }

--- a/cmake/preset-configure.json
+++ b/cmake/preset-configure.json
@@ -17,6 +17,7 @@
       "name": "clang-debug",
       "inherits": [ "cfg-clang", "cfg-c++23", "cfg-debug" ]
     },
+
     {
       "name": "clang-debug-c++26",
       "inherits": [ "cfg-clang", "cfg-c++26", "cfg-debug" ]
@@ -45,29 +46,56 @@
       "name": "clang-release-test-asan",
       "inherits": [ "cfg-clang", "cfg-libc++", "cfg-release", "cfg-asan", "cfg-build-dir" ]
     },
+    
+    {
+      "name": "module-clang-debug",
+      "inherits": [ "clang-debug", "cfg-module" ]
+    },
+    {
+      "name": "module-clang-debug-libstdc++",
+      "inherits": [ "clang-debug-libstdc++", "cfg-module" ]
+    },
+    {
+      "name": "module-gcc-debug",
+      "inherits": [ "gcc-debug", "cfg-module" ]
+    },
+    
     {
       "name": "ci-clang-libstdc++",
-      "inherits": [ "cfg-clang", "cfg-build-dir", "cfg-glaze", "cfg-c++23" ]
+      "inherits": [ "cfg-clang", "cfg-build-dir",  "cfg-c++23" ]
     },
     {
       "name": "ci-clang-libc++",
-      "inherits": [ "cfg-clang", "cfg-libc++", "cfg-build-dir", "cfg-glaze", "cfg-c++23" ]
+      "inherits": [ "cfg-clang", "cfg-libc++", "cfg-build-dir",  "cfg-c++23" ]
     },
     {
       "name": "ci-gcc",
-      "inherits": [ "cfg-gcc", "cfg-build-dir", "cfg-glaze", "cfg-c++23" ]
+      "inherits": [ "cfg-gcc", "cfg-build-dir",  "cfg-c++23" ]
     },
     {
       "name": "ci-clang-libstdc++-c++26",
-      "inherits": [ "cfg-clang", "cfg-build-dir", "cfg-glaze", "cfg-c++26" ]
+      "inherits": [ "cfg-clang", "cfg-build-dir",  "cfg-c++26" ]
     },
     {
       "name": "ci-clang-libc++-c++26",
-      "inherits": [ "cfg-clang", "cfg-libc++", "cfg-build-dir", "cfg-glaze", "cfg-c++26" ]
+      "inherits": [ "cfg-clang", "cfg-libc++", "cfg-build-dir",  "cfg-c++26" ]
     },
     {
       "name": "ci-gcc-c++26",
-      "inherits": [ "cfg-gcc", "cfg-build-dir", "cfg-glaze", "cfg-c++26" ]
+      "inherits": [ "cfg-gcc", "cfg-build-dir",  "cfg-c++26" ]
+    },
+    
+    {
+      "name": "ci-module-clang-libstdc++",
+      "inherits": [ "ci-clang-libstdc++", "cfg-module" ]
+    },
+    {
+      "name": "ci-module-clang-libc++",
+      "inherits": [ "ci-clang-libc++", "cfg-module" ]
+    },
+    {
+      "name": "ci-module-gcc",
+      "inherits": [ "ci-gcc", "cfg-module" ]
     }
   ]
 }

--- a/cmake/preset-options.json
+++ b/cmake/preset-options.json
@@ -7,6 +7,11 @@
   },
 "configurePresets": [
     {
+      "name": "cfg-module",
+      "hidden": true,
+      "cacheVariables": { "SIMPLE_ENUM_ENABLE_MODULE": "ON" }
+    },
+    {
       "name": "cfg-c++23",
       "hidden": true,
       "cacheVariables": { "CMAKE_CXX_STANDARD": "23" }
@@ -68,14 +73,6 @@
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-ggdb -fvisibility=default -fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined",
         "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address -fsanitize=undefined"
-      }
-    },
-    {
-    "name": "cfg-glaze",
-    "hidden": true,
-      "cacheVariables": {
-        "SIMPLE_ENUM_USE_GLAZE_3_1" : "OFF",
-        "SIMPLE_ENUM_USE_GLAZE_4_0" : "ON"
       }
     },
     {

--- a/cmake/preset-test.json
+++ b/cmake/preset-test.json
@@ -50,6 +50,28 @@
       "output": {
         "outputOnFailure": true
       }
+    },
+    
+    {
+      "name": "ci-module-clang-libstdc++",
+      "configurePreset": "ci-module-clang-libstdc++",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "ci-module-clang-libc++",
+      "configurePreset": "ci-module-clang-libc++",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "ci-module-gcc",
+      "configurePreset": "ci-module-gcc",
+      "output": {
+        "outputOnFailure": true
+      }
     }
   ]
 }

--- a/cmake/preset-workflow.json
+++ b/cmake/preset-workflow.json
@@ -110,6 +110,58 @@
           "name": "ci-gcc"
         }
       ]
+    },
+    
+    {
+      "name": "ci-module-clang-libstdc++",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "ci-module-clang-libstdc++"
+        },
+        {
+          "type": "build",
+          "name": "ci-module-clang-libstdc++"
+        },
+        {
+          "type": "test",
+          "name": "ci-module-clang-libstdc++"
+        }
+      ]
+    },
+    {
+      "name": "ci-module-clang-libc++",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "ci-module-clang-libc++"
+        },
+        {
+          "type": "build",
+          "name": "ci-module-clang-libc++"
+        },
+        {
+          "type": "test",
+          "name": "ci-module-clang-libc++"
+        }
+      ]
+    },
+    {
+      "name": "ci-module-gcc",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "ci-module-gcc"
+        },
+        {
+          "type": "build",
+          "name": "ci-module-gcc"
+        },
+        {
+          "type": "test",
+          "name": "ci-module-gcc"
+        }
+      ]
     }
   ]
 }

--- a/ext_support/simple_enum/fmtlib_format.hpp
+++ b/ext_support/simple_enum/fmtlib_format.hpp
@@ -3,7 +3,11 @@
 // SPDX-PackageHomePage: https://github.com/arturbac/simple_enum
 #pragma once
 
+#ifdef SIMPLE_ENUM_CXX_MODULE
+import simple_enum;
+#else
 #include <simple_enum/simple_enum.hpp>
+#endif
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Weverything"

--- a/include/simple_enum/core.hpp
+++ b/include/simple_enum/core.hpp
@@ -6,10 +6,11 @@
 #include <concepts>
 #include <type_traits>
 
-#define SIMPLE_ENUM_NAME_VERSION "0.8.10"
+#define SIMPLE_ENUM_NAME_VERSION "0.8.11"
 
 namespace simple_enum::inline v0_8
   {
+inline constexpr auto simple_enum_name_version{SIMPLE_ENUM_NAME_VERSION};
 
 #ifndef SIMPLE_ENUM_CUSTOM_UNBOUNDED_RANGE
 #define SIMPLE_ENUM_CUSTOM_UNBOUNDED_RANGE

--- a/include/simple_enum/enum_cast.hpp
+++ b/include/simple_enum/enum_cast.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <iterator>
 #include <simple_enum/expected.h>
+#include "detail/static_call_operator_prolog.h"
 
 namespace simple_enum::inline v0_8
   {
@@ -124,7 +125,8 @@ template<enum_concept enum_type>
 struct enum_cast_t
   {
   [[nodiscard]]
-  static constexpr auto operator()(std::string_view value) noexcept -> cxx23::expected<enum_type, enum_cast_error>
+  static_call_operator constexpr auto operator()(std::string_view value) static_call_operator_const noexcept
+    -> cxx23::expected<enum_type, enum_cast_error>
     {
     using enum_meta_info = detail::enum_meta_info_t<enum_type>;
     using underlying_type = std::underlying_type_t<enum_type>;
@@ -174,3 +176,4 @@ inline constexpr enum_cast_t<enum_type> enum_cast{};
 
   }  // namespace simple_enum::inline v0_8
 
+#include "detail/static_call_operator_epilog.h"

--- a/include/simple_enum/enum_cast.hpp
+++ b/include/simple_enum/enum_cast.hpp
@@ -11,8 +11,6 @@
 #include <iterator>
 #include <simple_enum/expected.h>
 
-#include "detail/static_call_operator_prolog.h"
-
 namespace simple_enum::inline v0_8
   {
 using cxx23::bad_expected_access;
@@ -116,19 +114,17 @@ enum struct enum_cast_error
   invalid_cast
   };
 
-template<>
-struct info<enum_cast_error>
+consteval auto adl_enum_bounds(enum_cast_error)
   {
-  static constexpr auto first = enum_cast_error::invalid_cast;
-  static constexpr auto last = enum_cast_error::invalid_cast;
-  };
+  using enum enum_cast_error;
+  return simple_enum::adl_info{invalid_cast, invalid_cast};
+  }
 
 template<enum_concept enum_type>
 struct enum_cast_t
   {
   [[nodiscard]]
-  static_call_operator constexpr auto operator()(std::string_view value) static_call_operator_const noexcept
-    -> cxx23::expected<enum_type, enum_cast_error>
+  static constexpr auto operator()(std::string_view value) noexcept -> cxx23::expected<enum_type, enum_cast_error>
     {
     using enum_meta_info = detail::enum_meta_info_t<enum_type>;
     using underlying_type = std::underlying_type_t<enum_type>;
@@ -178,4 +174,3 @@ inline constexpr enum_cast_t<enum_type> enum_cast{};
 
   }  // namespace simple_enum::inline v0_8
 
-#include "detail/static_call_operator_epilog.h"

--- a/include/simple_enum/enum_index.hpp
+++ b/include/simple_enum/enum_index.hpp
@@ -6,8 +6,6 @@
 #include <simple_enum/simple_enum.hpp>
 #include <simple_enum/expected.h>
 
-#include "detail/static_call_operator_prolog.h"
-
 namespace simple_enum::inline v0_8
   {
 using cxx23::bad_expected_access;
@@ -23,19 +21,17 @@ enum struct enum_index_error
   out_of_range
   };
 
-template<>
-struct info<enum_index_error>
+consteval auto adl_enum_bounds(enum_index_error)
   {
-  static constexpr auto first = enum_index_error::out_of_range;
-  static constexpr auto last = enum_index_error::out_of_range;
-  };
+  using enum enum_index_error;
+  return simple_enum::adl_info{out_of_range, out_of_range};
+  }
 
 struct enum_index_t
   {
   template<enum_concept enum_type>
   [[nodiscard]]
-  static_call_operator constexpr auto operator()(enum_type value
-  ) static_call_operator_const noexcept -> cxx23::expected<std::size_t, enum_index_error>
+  static constexpr auto operator()(enum_type value) noexcept -> cxx23::expected<std::size_t, enum_index_error>
     {
     using enum_meta_info = detail::enum_meta_info_t<enum_type>;
     auto const requested_index{simple_enum::detail::to_underlying(value)};
@@ -82,5 +78,3 @@ consteval auto consteval_enum_index() -> std::size_t
   }
 
   }  // namespace simple_enum::inline v0_8
-
-#include "detail/static_call_operator_epilog.h"

--- a/include/simple_enum/enum_index.hpp
+++ b/include/simple_enum/enum_index.hpp
@@ -5,6 +5,7 @@
 
 #include <simple_enum/simple_enum.hpp>
 #include <simple_enum/expected.h>
+#include "detail/static_call_operator_prolog.h"
 
 namespace simple_enum::inline v0_8
   {
@@ -31,7 +32,8 @@ struct enum_index_t
   {
   template<enum_concept enum_type>
   [[nodiscard]]
-  static constexpr auto operator()(enum_type value) noexcept -> cxx23::expected<std::size_t, enum_index_error>
+  static_call_operator constexpr auto operator()(enum_type value) static_call_operator_const noexcept
+    -> cxx23::expected<std::size_t, enum_index_error>
     {
     using enum_meta_info = detail::enum_meta_info_t<enum_type>;
     auto const requested_index{simple_enum::detail::to_underlying(value)};
@@ -78,3 +80,5 @@ consteval auto consteval_enum_index() -> std::size_t
   }
 
   }  // namespace simple_enum::inline v0_8
+
+#include "detail/static_call_operator_epilog.h"

--- a/include/simple_enum/indexed_access.hpp
+++ b/include/simple_enum/indexed_access.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 Artur Bać
+// SPDX-License-Identifier: BSL-1.0
+// SPDX-PackageHomePage: https://github.com/arturbac/simple_enum
+#pragma once
+#include <simple_enum/simple_enum.hpp>
+
+namespace simple_enum::inline v0_8
+  {
+
+template<bounded_enum enumeration_type>
+constexpr auto enum_size() -> size_t
+  {
+  return detail::enum_base_info_t<enumeration_type>::size();
+  }
+
+template<bounded_enum enumeration_type>
+constexpr auto enum_value_at_index(size_t ix) -> enumeration_type
+  {
+  using underlying_type = std::underlying_type_t<enumeration_type>;
+  return static_cast<enumeration_type>(detail::enum_base_info_t<enumeration_type>::first_index() + underlying_type(ix));
+  }
+
+template<bounded_enum enumeration_type>
+constexpr auto enum_name_at_index(size_t ix) -> std::string_view
+  {
+  return detail::enum_meta_info_t<enumeration_type>::meta_data[ix].as_view();
+  }
+  }  // namespace simple_enum::inline v0_8

--- a/include/simple_enum/simple_enum.hpp
+++ b/include/simple_enum/simple_enum.hpp
@@ -12,8 +12,6 @@
 #endif
 #include <array>
 
-#include "detail/static_call_operator_prolog.h"
-
 namespace simple_enum::inline v0_8
   {
 namespace detail
@@ -376,8 +374,7 @@ namespace detail
 struct enum_name_t
   {
   template<enum_concept enum_type>
-  static_call_operator constexpr auto operator()(enum_type value) static_call_operator_const noexcept
-    -> std::string_view
+  static constexpr auto operator()(enum_type value) noexcept -> std::string_view
     {
     using enum_meta_info = detail::enum_meta_info_t<enum_type>;
     auto const requested_index{simple_enum::detail::to_underlying(value)};
@@ -461,7 +458,6 @@ namespace limits
   template<bounded_enum enumeration>
   inline constexpr detail::max_t<enumeration> max{};
   }  // namespace limits
-  }  // namespace simple_enum::inline v0_8
 
-#include "detail/static_call_operator_epilog.h"
+  }  // namespace simple_enum::inline v0_8
 

--- a/include/simple_enum/simple_enum.hpp
+++ b/include/simple_enum/simple_enum.hpp
@@ -11,6 +11,7 @@
 #include <source_location>
 #endif
 #include <array>
+#include "detail/static_call_operator_prolog.h"
 
 namespace simple_enum::inline v0_8
   {
@@ -374,7 +375,7 @@ namespace detail
 struct enum_name_t
   {
   template<enum_concept enum_type>
-  static constexpr auto operator()(enum_type value) noexcept -> std::string_view
+  static_call_operator constexpr auto operator()(enum_type value) noexcept static_call_operator_const->std::string_view
     {
     using enum_meta_info = detail::enum_meta_info_t<enum_type>;
     auto const requested_index{simple_enum::detail::to_underlying(value)};
@@ -461,3 +462,4 @@ namespace limits
 
   }  // namespace simple_enum::inline v0_8
 
+#include "detail/static_call_operator_epilog.h"

--- a/include/simple_enum/simple_enum.hpp
+++ b/include/simple_enum/simple_enum.hpp
@@ -375,7 +375,8 @@ namespace detail
 struct enum_name_t
   {
   template<enum_concept enum_type>
-  static_call_operator constexpr auto operator()(enum_type value) noexcept static_call_operator_const->std::string_view
+  static_call_operator constexpr auto operator()(enum_type value) noexcept static_call_operator_const  //
+    -> std::string_view
     {
     using enum_meta_info = detail::enum_meta_info_t<enum_type>;
     auto const requested_index{simple_enum::detail::to_underlying(value)};
@@ -463,3 +464,4 @@ namespace limits
   }  // namespace simple_enum::inline v0_8
 
 #include "detail/static_call_operator_epilog.h"
+

--- a/include/simple_enum/simple_enum.hpp
+++ b/include/simple_enum/simple_enum.hpp
@@ -375,7 +375,7 @@ namespace detail
 struct enum_name_t
   {
   template<enum_concept enum_type>
-  static_call_operator constexpr auto operator()(enum_type value) noexcept static_call_operator_const  //
+  static_call_operator constexpr auto operator()(enum_type value) static_call_operator_const noexcept
     -> std::string_view
     {
     using enum_meta_info = detail::enum_meta_info_t<enum_type>;

--- a/include/simple_enum/std_format.hpp
+++ b/include/simple_enum/std_format.hpp
@@ -5,11 +5,7 @@
 
 #include <simple_enum/simple_enum.hpp>
 #include <type_traits>
-
-#if (defined(__cpp_lib_format) && !(defined(__clang__) && defined(__GLIBCXX__) && __GLIBCXX__ < 202103L)) \
-  || ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 1800 || __GLIBCXX__ >= 202103L) && __cplusplus >= 202002L)
 #include <format>
-#define SIMPLE_ENUM_STD_FORMAT_ENABLED
 
 template<simple_enum::enum_concept enumeration>
 struct std::formatter<enumeration>
@@ -26,6 +22,4 @@ struct std::formatter<enumeration>
     return std::format_to(ctx.out(), "{}", simple_enum::enum_name(e));
     }
   };
-
-#endif  // __cpp_lib_format or C++20
 

--- a/module/simple_enum.cxx
+++ b/module/simple_enum.cxx
@@ -1,0 +1,71 @@
+module;
+#include <simple_enum/simple_enum.hpp>
+#include <simple_enum/enum_index.hpp>
+#include <simple_enum/enum_cast.hpp>
+#include <simple_enum/generic_error_category.hpp>
+#include <simple_enum/generic_error_category_impl.hpp>
+#include <simple_enum/ranges_views.hpp>
+#include <simple_enum/indexed_access.hpp>
+#include <simple_enum/std_format.hpp>
+#include <simple_enum/basic_fixed_string.hpp>
+
+export module simple_enum;
+
+export namespace simple_enum
+  {
+
+using simple_enum::bounded_enum;
+using simple_enum::enum_concept;
+
+namespace concepts
+  {
+  using simple_enum::bounded_enum;
+  using simple_enum::concepts::declared_error_code;
+  using simple_enum::concepts::error_enum;
+  using simple_enum::enum_concept;
+  }  // namespace concepts
+
+using simple_enum::adl_info;
+using simple_enum::enum_name;
+using simple_enum::enum_name_at_index;
+using simple_enum::enum_name_t;
+using simple_enum::enum_size;
+using simple_enum::enum_value_at_index;
+using simple_enum::enumeration_name_v;
+using simple_enum::info;
+
+namespace limits
+  {
+  using simple_enum::limits::max;
+  using simple_enum::limits::min;
+  }  // namespace limits
+
+using simple_enum::consteval_enum_index;
+using simple_enum::enum_index;
+using simple_enum::enum_index_error;
+using simple_enum::enum_index_t;
+
+using simple_enum::enum_cast;
+using simple_enum::enum_cast_error;
+using simple_enum::enum_cast_t;
+
+using simple_enum::expected;
+using simple_enum::expected_ec;
+using simple_enum::generic_error_category;
+using simple_enum::make_error_code;
+using simple_enum::make_unexpected_ec;
+using simple_enum::unexpected;
+using simple_enum::unexpected_ec;
+
+using simple_enum::as_basic_fixed_string;
+using simple_enum::basic_fixed_string;
+using simple_enum::string_literal;
+using simple_enum::to_camel_case;
+
+using simple_enum::enum_enumerations;
+using simple_enum::enum_view;
+
+using simple_enum::begin;
+using simple_enum::end;
+using simple_enum::enum_names;
+  }  // namespace simple_enum

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,45 +13,6 @@ cpmaddpackage(
   GIT_TAG
   v2.0.1_7)
 find_package(ut-ext REQUIRED)
-if(SIMPLE_ENUM_ENABLE_TIME_TRACE
-   AND (CMAKE_CXX_COMPILER_ID
-        MATCHES
-        "Clang"
-        OR CMAKE_CXX_COMPILER_ID
-           MATCHES
-           "AppleClang"
-       ))
-  # external dependencies only for comparison benchmarking
-  cpmaddpackage(
-    NAME
-    magic_enum
-    GITHUB_REPOSITORY
-    Neargye/magic_enum
-    GIT_TAG
-    v0.9.5
-    GIT_SHALLOW
-    TRUE)
-  find_package(magic_enum REQUIRED)
-
-  cpmaddpackage(
-    Name
-    reflect
-    GITHUB_REPOSITORY
-    boost-ext/reflect
-    GIT_TAG
-    main
-    GIT_SHALLOW
-    TRUE)
-
-  add_library(reflect INTERFACE)
-  target_include_directories(reflect SYSTEM INTERFACE ${reflect_SOURCE_DIR})
-  target_compile_definitions(reflect INTERFACE REFLECT_DISABLE_STATIC_ASSERT_TESTS)
-  add_library(
-    reflect::reflect
-    ALIAS
-    reflect)
-  find_package(reflect REQUIRED)
-endif()
 
 # ----------------------------------------------------------------
 # glaze

--- a/tests/enum_cast_ut.cc
+++ b/tests/enum_cast_ut.cc
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2024 Artur Bać
 // SPDX-License-Identifier: BSL-1.0
 // SPDX-PackageHomePage: https://github.com/arturbac/simple_enum
+#ifndef SIMPLE_ENUM_CXX_MODULE
 #include <simple_enum/enum_cast.hpp>
+#endif
 #include "simple_enum_tests.hpp"
 #include <utility>
 
@@ -9,6 +11,7 @@ namespace simple_enum
   {
 static void enum_cast_test()
   {
+#ifndef SIMPLE_ENUM_CXX_MODULE
   "bl_lower_bound"_test = []
   {
     using simple_enum::detail::bound_leaning_lower_bound;
@@ -43,6 +46,7 @@ static void enum_cast_test()
       expect(it == std::lower_bound(data.begin(), data.end(), 70, std::less<int>{}));
       }
   };
+#endif
   "enum_cast success"_test = []
   {
     using enum lorem_ipsum_long;

--- a/tests/enum_index_ut.cc
+++ b/tests/enum_index_ut.cc
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2024 Artur Bać
 // SPDX-License-Identifier: BSL-1.0
 // SPDX-PackageHomePage: https://github.com/arturbac/simple_enum
+#ifndef SIMPLE_ENUM_CXX_MODULE
 #include <simple_enum/enum_index.hpp>
+#endif
 #include "simple_enum_tests.hpp"
 
 using simple_enum::enum_index;
@@ -11,7 +13,7 @@ int main()
   {
   "enum_index valid"_test = []
   {
-    using simple_enum::detail::to_underlying;
+    using std::to_underlying;
 
     expect(eq(enum_index(lorem_ipsum_short::eu).value(), to_underlying(lorem_ipsum_short::eu)));
     expect(eq(enum_index(lorem_ipsum_short::adipiscing).value(), to_underlying(lorem_ipsum_short::adipiscing)));
@@ -19,16 +21,18 @@ int main()
 
     expect(eq(enum_index(weak::weak_typed_e::v2).value(), 1u));
     expect(eq(enum_index(test::subnamespace::example_3_e::v2).value(), 1u));
+#ifndef SIMPLE_ENUM_CXX_MODULE
       {
       using mf = simple_enum::detail::enum_meta_info_t<weak::weak_typed_e>;
       static_assert(static_cast<weak::weak_typed_e>(mf::first_index()) == weak::v1);
       static_assert(static_cast<weak::weak_typed_e>(mf::last_index()) == weak::v3);
       }
+#endif
   };
 
   "enum_index out_of_range"_test = []
   {
-    using simple_enum::detail::to_underlying;
+    using std::to_underlying;
     auto out_of_range_value = static_cast<lorem_ipsum_short>(to_underlying(lorem_ipsum_short::last) + 1);
     expect(enum_index(out_of_range_value).error() == enum_index_error::out_of_range);
   };

--- a/tests/fmtlib_format_ut.cc
+++ b/tests/fmtlib_format_ut.cc
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Artur Bać
 // SPDX-License-Identifier: BSL-1.0
 // SPDX-PackageHomePage: https://github.com/arturbac/simple_enum
-#include <simple_enum/fmtlib_format.hpp>
 #include "simple_enum_tests.hpp"
+#include <simple_enum/fmtlib_format.hpp>
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/tests/generic_error_category_ut.cc
+++ b/tests/generic_error_category_ut.cc
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: 2024 Artur Bać
 // SPDX-License-Identifier: BSL-1.0
 // SPDX-PackageHomePage: https://github.com/arturbac/simple_enum
+#ifndef SIMPLE_ENUM_CXX_MODULE
 #include <simple_enum/generic_error_category_impl.hpp>
 #include <simple_enum/basic_fixed_string.hpp>
+#endif
 #include "simple_enum_tests.hpp"
 
 using namespace boost::ut;
@@ -106,8 +108,9 @@ static_assert(to_camel_case(basic_fixed_string{"a "}) == basic_fixed_string{"A "
 static_assert(
   to_camel_case(basic_fixed_string{"hello world"}) != basic_fixed_string{"hello world"}, "Incorrect CamelCase equality"
 );
+#ifndef SIMPLE_ENUM_CXX_MODULE
 static_assert(!simple_enum::detail::error_category_name_specialized<test_error>);
-
+#endif
 enum class test_error_class_spec
   {
   success = 0,
@@ -126,9 +129,9 @@ struct std::is_error_code_enum<test_error_class_spec> : true_type
   {
   static constexpr std::string_view category_name = "My Custom Error Category Name";
   };
-
+#ifndef SIMPLE_ENUM_CXX_MODULE
 static_assert(simple_enum::detail::error_category_name_specialized<test_error_class_spec>);
-
+#endif
 namespace test_adl_decl_error_code
   {
 enum class test_adl_decl_error_code
@@ -148,7 +151,9 @@ consteval auto adl_decl_error_code(test_adl_decl_error_code) -> bool { return tr
 
 static_assert(simple_enum::concepts::declared_error_code<test_adl_decl_error_code>);
 static_assert(std::is_error_code_enum<test_adl_decl_error_code>::value);
+#ifndef SIMPLE_ENUM_CXX_MODULE
 static_assert(!simple_enum::detail::error_category_name_specialized<test_adl_decl_error_code>);
+#endif
   }  // namespace test_adl_decl_error_code
 
 namespace test_non_adl_decl_error_code
@@ -165,8 +170,9 @@ consteval auto adl_enum_bounds(test_non_adl_decl_error_code)
   using enum test_non_adl_decl_error_code;
   return simple_enum::adl_info{success, unknown};
   }
-
+#ifndef SIMPLE_ENUM_CXX_MODULE
 static_assert(!simple_enum::detail::error_category_name_specialized<test_non_adl_decl_error_code>);
+#endif
 static_assert(!std::is_error_code_enum<test_non_adl_decl_error_code>::value);
 
 namespace test_adl_enum_bounds_error_code
@@ -186,9 +192,11 @@ namespace test_adl_enum_bounds_error_code
     }
 
   static_assert(adl_enum_bounds(strong_typed_as_error{}).error_code_enum);
+#ifndef SIMPLE_ENUM_CXX_MODULE
   static_assert(simple_enum::detail::has_valid_adl_enum_bounds<strong_typed_as_error>);
 
   static_assert(simple_enum::detail::adl_info_error_declared_enum<strong_typed_as_error>);
+#endif
   static_assert(simple_enum::concepts::declared_error_code<strong_typed_as_error>);
   static_assert(std::is_error_code_enum<strong_typed_as_error>::value);
   }  // namespace test_adl_enum_bounds_error_code

--- a/tests/glaze_enum_name_ut.cc
+++ b/tests/glaze_enum_name_ut.cc
@@ -1,14 +1,18 @@
 // SPDX-FileCopyrightText: 2024 Artur Bać
 // SPDX-License-Identifier: BSL-1.0
 // SPDX-PackageHomePage: https://github.com/arturbac/simple_enum
-#include <simple_enum/glaze_json_enum_name.hpp>
+
 #include <glaze/ext/jsonrpc.hpp>
-#include <simple_enum/ranges_views.hpp>
-#include "simple_enum_tests.hpp"
+
 #include <tuple>
 #include <ranges>
 #include <utility>
 #include <algorithm>
+#include "simple_enum_tests.hpp"
+#include <simple_enum/glaze_json_enum_name.hpp>
+#ifndef SIMPLE_ENUM_CXX_MODULE
+#include <simple_enum/ranges_views.hpp>
+#endif
 
 namespace views = std::views;
 namespace ranges = std::ranges;

--- a/tests/ranges_views_ut.cc
+++ b/tests/ranges_views_ut.cc
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2024 Artur Bać
 // SPDX-License-Identifier: BSL-1.0
 // SPDX-PackageHomePage: https://github.com/arturbac/simple_enum
+#ifndef SIMPLE_ENUM_CXX_MODULE
 #include <simple_enum/ranges_views.hpp>
+#endif
 #include "simple_enum_tests.hpp"
 #include <ranges>
 

--- a/tests/simple_enum_tests.hpp
+++ b/tests/simple_enum_tests.hpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSL-1.0
 // SPDX-PackageHomePage: https://github.com/arturbac/simple_enum
 #pragma once
-#include "simple_enum/simple_enum.hpp"
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wctad-maybe-unsupported"
@@ -15,7 +15,6 @@
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
-#include "enum_definitions.h"
 
 namespace ut = boost::ut;
 using ut::eq;
@@ -30,6 +29,13 @@ using namespace std::string_view_literals;
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
+#ifdef SIMPLE_ENUM_CXX_MODULE
+import simple_enum;
+#else
+#include "simple_enum/simple_enum.hpp"
+#endif
+#include "enum_definitions.h"
+
 std::ostream & operator<<(std::ostream & os, simple_enum::enum_concept auto const & value)
   {
   os << simple_enum::enum_name(value);

--- a/tests/std_format_ut.cc
+++ b/tests/std_format_ut.cc
@@ -1,17 +1,18 @@
 // SPDX-FileCopyrightText: 2024 Artur Bać
 // SPDX-License-Identifier: BSL-1.0
 // SPDX-PackageHomePage: https://github.com/arturbac/simple_enum
+#ifndef SIMPLE_ENUM_CXX_MODULE
 #include <simple_enum/std_format.hpp>
+#endif
+#include <format>
 #include "simple_enum_tests.hpp"
 #include <concepts>
 
 int main()
   {
-#ifdef SIMPLE_ENUM_STD_FORMAT_ENABLED
   "std::format formatter test"_test = []
   {
     expect(std::format("{}", lorem_ipsum_short::eu) == std::string_view{"eu"});
     expect(std::format("{}", lorem_ipsum_short::occaecat) == std::string_view{"occaecat"});
   };
-#endif
   }

--- a/tests/test_simple_enum.cc
+++ b/tests/test_simple_enum.cc
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2024 Artur Bać
 // SPDX-License-Identifier: BSL-1.0
 // SPDX-PackageHomePage: https://github.com/arturbac/simple_enum
-
+#ifndef SIMPLE_ENUM_CXX_MODULE
 #define SIMPLE_ENNUM_ENABLE_PEN_TEST
-
+#endif
 #include "simple_enum_tests.hpp"
 
 // TODO chck impact of clang-18 attribute
@@ -26,8 +26,10 @@ enum struct enum_bounded
 
 consteval auto adl_enum_bounds(enum_bounded) { return simple_enum::adl_info{enum_bounded::v1, enum_bounded::v3}; }
 
+#ifndef SIMPLE_ENUM_CXX_MODULE
 static_assert(simple_enum::detail::enum_meta_info_t<enum_bounded>::first() == enum_bounded::v1);
 static_assert(simple_enum::detail::enum_meta_info_t<enum_bounded>::last() == enum_bounded::v3);
+#endif
 
 static_assert(simple_enum::limits::min<enum_bounded>() == enum_bounded::v1);
 static_assert(simple_enum::limits::max<enum_bounded>() == enum_bounded::v3);
@@ -39,8 +41,10 @@ enum struct enum_upper_bounded
   v3,
   last = v3
   };
+#ifndef SIMPLE_ENUM_CXX_MODULE
 static_assert(simple_enum::detail::enum_meta_info_t<enum_upper_bounded>::first() == static_cast<enum_upper_bounded>(0));
 static_assert(simple_enum::detail::enum_meta_info_t<enum_upper_bounded>::last() == enum_upper_bounded::last);
+#endif
 
 enum struct enum_lower_bounded
   {
@@ -49,11 +53,13 @@ enum struct enum_lower_bounded
   first = v1
   };
 
+#ifndef SIMPLE_ENUM_CXX_MODULE
 static_assert(simple_enum::detail::enum_meta_info_t<enum_lower_bounded>::first() == enum_lower_bounded::v1);
 static_assert(
   simple_enum::detail::enum_meta_info_t<enum_lower_bounded>::last()
   == static_cast<enum_lower_bounded>(simple_enum::default_unbounded_upper_range)
 );
+#endif
 
 enum struct enum_unbounded
   {
@@ -70,6 +76,7 @@ enum struct enum_unbounded_sparse
   v1 = 9,
   v2
   };
+#ifndef SIMPLE_ENUM_CXX_MODULE
 static_assert(
   simple_enum::detail::enum_meta_info_t<enum_unbounded_sparse>::first() == static_cast<enum_unbounded_sparse>(0)
 );
@@ -77,7 +84,7 @@ static_assert(
   simple_enum::detail::enum_meta_info_t<enum_unbounded_sparse>::last()
   == static_cast<enum_unbounded_sparse>(simple_enum::default_unbounded_upper_range)
 );
-
+#endif
 enum weak_global_untyped_e
   {
   v1 = 1,
@@ -107,10 +114,10 @@ struct simple_enum::info<global_untyped_externaly_e>
   static constexpr auto first = global_untyped_externaly_e::v1;
   static constexpr auto last = global_untyped_externaly_e::v3;
   };
-
+#ifndef SIMPLE_ENUM_CXX_MODULE
 static_assert(simple_enum::detail::enum_meta_info_t<global_untyped_externaly_e>::first_index() == 1);
 static_assert(simple_enum::detail::enum_meta_info_t<global_untyped_externaly_e>::last_index() == 3);
-
+#endif
 namespace simple_enum
   {
 
@@ -264,7 +271,7 @@ enum struct sparse_offseted_untyped
   first = unknown,  // simulate counting below the range
   last = v3
   };
-
+#ifndef SIMPLE_ENUM_CXX_MODULE
 using detail::cont_pass;
 using detail::first_pass;
 using detail::meta_name;
@@ -278,6 +285,7 @@ constexpr auto se_view() noexcept -> std::string_view
   cont_pass<enumeration>(value, beg);
   return std::string_view{value.data, value.size};
   }
+#endif
 // " (strong_typed)0]"
 // " strong_typed::v1]"
 // " strong_typed::v1]"
@@ -292,7 +300,7 @@ enum struct test_enumeration_name
   v2,
   last_en
   };
-
+#ifndef SIMPLE_ENUM_CXX_MODULE
 static ut::suite<"msv tests"> msvc_tests = []
 {
   "test auto __cdecl se::f<(enum strong_typed)0x0>(void) noexcept"_test = []
@@ -388,6 +396,7 @@ static ut::suite<"msv tests"> msvc_tests = []
     expect(eq(std::string_view{result.data, result.size}, "example_5_e"sv));
   };
 };
+
 static ut::suite<"enumeratioN_name"> enumeratioN_name = []
 {
   using namespace ut;
@@ -434,7 +443,7 @@ static ut::suite<"enumeratioN_name"> enumeratioN_name = []
     expect(eq(std::string_view{result.data, result.size}, "strong_typed"sv));
   };
 };
-
+#endif
 enum class ScopedEnum
   {
   SE_Value1,
@@ -451,10 +460,12 @@ enum class MultiValuedEnum
   Value2,
   Value3
   };
+
 static ut::suite<"enumeration_name_tests"> enumeration_name_tests = []
 {
   "ScopedEnum_name"_test = []
   {
+#ifndef SIMPLE_ENUM_CXX_MODULE
     char const * const func{se::f<ScopedEnum{}>()};
     meta_name result;
 #ifdef __clang__
@@ -465,11 +476,13 @@ static ut::suite<"enumeration_name_tests"> enumeration_name_tests = []
 #pragma clang unsafe_buffer_usage end
 #endif
     expect(eq(result.as_view(), "ScopedEnum"sv));
+#endif
     expect(eq(enumeration_name_v<ScopedEnum>, "ScopedEnum"sv));
   };
 
   "EmptyEnum_name"_test = []
   {
+#ifndef SIMPLE_ENUM_CXX_MODULE
     char const * const func{se::f<EmptyEnum{}>()};
     meta_name result;
 #ifdef __clang__
@@ -480,11 +493,13 @@ static ut::suite<"enumeration_name_tests"> enumeration_name_tests = []
 #pragma clang unsafe_buffer_usage end
 #endif
     expect(eq(result.as_view(), "EmptyEnum"sv)) << func;
+#endif
     expect(eq(enumeration_name_v<EmptyEnum>, "EmptyEnum"sv));
   };
 
   "MultiValuedEnum_name"_test = []
   {
+#ifndef SIMPLE_ENUM_CXX_MODULE
     char const * const func{se::f<MultiValuedEnum{}>()};
     meta_name result;
 #ifdef __clang__
@@ -495,12 +510,14 @@ static ut::suite<"enumeration_name_tests"> enumeration_name_tests = []
 #pragma clang unsafe_buffer_usage end
 #endif
     expect(eq(result.as_view(), "MultiValuedEnum"sv)) << func;
+#endif
     expect(eq(enumeration_name_v<MultiValuedEnum>, "MultiValuedEnum"sv));
   };
 };
 static ut::suite<"simple_enum"> _ = []
 {
   using namespace ut;
+#ifndef SIMPLE_ENUM_CXX_MODULE
   "test enum_unbounded_sparse offseting"_test = []
   {
     constexpr auto v{static_cast<enum_unbounded_sparse>(0)};
@@ -510,7 +527,7 @@ static ut::suite<"simple_enum"> _ = []
     cont_pass<enum_unbounded_sparse::v1>(value, offset);
     cont_pass<enum_unbounded_sparse::v2>(value, offset);
   };
-
+#endif
   "test unbounded"_test = []
   {
     ut::expect(enum_name(enum_unbounded::v1) == "v1");
@@ -531,7 +548,7 @@ static ut::suite<"simple_enum"> _ = []
     // TESTING UB dosabled
     // ut::expect(enum_name(static_cast<sparse_offseted_untyped>(0)) == "0");
   };
-
+#ifndef SIMPLE_ENUM_CXX_MODULE
   "test se meta name cut"_test = []
   {
     // ut::expect(se_view<weak_global_untyped_e::v1>() == "v1");
@@ -576,6 +593,7 @@ static ut::suite<"simple_enum"> _ = []
     ut::expect(se_view<test::subnamespace::weak_typed_5_e::v2>() == "v2");
     ut::expect(se_view<test::subnamespace::weak_typed_5_e::v3>() == "v3");
   };
+#endif
   "test enum name"_test = []
   {
     ut::expect(enum_name(weak_global_untyped_e::v1) == "v1");
@@ -619,4 +637,9 @@ static ut::suite<"simple_enum"> _ = []
 
   }  // namespace simple_enum
 
-int main() { se::verify_offset(); }
+int main()
+  {
+#ifndef SIMPLE_ENUM_CXX_MODULE
+  se::verify_offset();
+#endif
+  }


### PR DESCRIPTION
- c++ module export only public interface, hide private detail namespace
- split addon headers for glaze and fmt from simple enum main include and module
- add enum_name_at_index, enum_size, enum_value_at_index to public interface